### PR TITLE
feat(OCR): output support newline

### DIFF
--- a/agentlego/tools/ocr/README.md
+++ b/agentlego/tools/ocr/README.md
@@ -19,6 +19,7 @@ tool = load_tool('OCR', device='cuda', lang='en', x_ths=3.)
 # apply tool
 res = tool('demo_kie.jpeg')
 ```
+For bilingual Chinese and English OCR, `lang` may be `['en', 'ch_sim']`, [here](https://www.jaided.ai/easyocr/) is all supported language code name.
 
 **With Lagent**
 

--- a/agentlego/tools/ocr/README.md
+++ b/agentlego/tools/ocr/README.md
@@ -14,7 +14,7 @@ wget https://raw.githubusercontent.com/open-mmlab/mmocr/main/demo/demo_kie.jpeg
 from agentlego.apis import load_tool
 
 # load tool
-tool = load_tool('OCR', device='cuda', lang='en', x_ths=3.)
+tool = load_tool('OCR', device='cuda', lang='en', x_ths=3., line_group_tolerance=30)
 
 # apply tool
 res = tool('demo_kie.jpeg')

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -7,3 +7,4 @@ torchaudio
 torchvision
 typing-extensions
 uvicorn[standard]
+easyocr


### PR DESCRIPTION

#### 1. add line group, better than `easyOCR paragraph=True`
here is my test code
```python
# master
tool1 = load_tool('OCR', device='cuda', lang=['en', 'ch_sim'], x_ths=3.)
print(tool1('chinese.jpg'))
print()

# add new feature
print('* enable line group')
tool2 = load_tool('OCR', device='cuda', lang=['en', 'ch_sim'], x_ths=3., line_group_tolerance=30)
print(tool2('chinese.jpg'))

tool3 = load_tool('OCR', device='cuda', lang=['en'], x_ths=3., line_group_tolerance=30)
print(tool3('demo_kie.jpeg'))
```

output
```bash
西 愚园路 东 315 309 W Yuyuan Rd。 E

* enable line group
西 愚园路 东
315 309
W Yuyuan Rd。 E
7/30/2012 8 27 32 PM L 8
Or der 113533 Cashier Eric H
Grande Meal 9 90 8
10 Bean Bur 0 00 1
Grande Meal 9.90
10 Bean Bur 0 00
10 No Onions 0.00 
1 Sft Tac Party Pk 10.00
12 Sft Taco Bf 0 00 3
Taco Parfy Pack 10.00 1
12 Crunchy Taco 0.00
26 Med Drnk 43 94
3 Supreme Pizza 11 97 8
3 Pepperoni Pizza 1 07 1
3 Cheese Pizza 10 47
SubTotal 117.25 1
Tax 11 02
Total 128,27 3
L
Mas ter Card 128,27
Acct XXXXXXXX8425
Approval :052723 8
8
```

#### 2. explain more usage 
If directly set `lang='ch_sim'`, I got this:
```bash
$ python3 test_agentlego.py 
西 愚园路 东 315 309 旧 丫4几 尺4。 匕
```

