### PR TITLE
[Fix] Fix gen_kwargs in lagent_agent

### DIFF
--- a/webui/modules/agents/lagent_agent.py
+++ b/webui/modules/agents/lagent_agent.py
@@ -69,7 +69,7 @@ class LMDeployClient(BaseModel):
             'suffix': None,
             'temperature': 0.7,
             'n': 1,
-            'max_tokens': 16,
+            'max_tokens': 1024,
             'stop': None,
             'top_p': 1.0,
             'top_k': 40,
@@ -78,6 +78,7 @@ class LMDeployClient(BaseModel):
             'session_id': -1,
             'ignore_eos': False,
             'stream': True,
+            'skip_special_tokens': False,
             **kwargs,
         }
         headers = {'content-type': 'application/json'}


### PR DESCRIPTION
修改了两部分，分别是修改了 `max_tokens` 为1024，以及加入了 `skip_special_tokens=False`。

对于 `max_tokens` 部分，16的最大 token 数会在模型在把图片路径传入给工具时，发生路径不完整的问题。

对于 `skip_special_tokens=False` 的问题，由于`skip_special_tokens` 默认为 True，（https://github.com/InternLM/lmdeploy/blob/b5b2b8bd1c578e1cc35fcaaf60742bf5c830fead/lmdeploy/messages.py#L50 ），这会导致 `<|action_start|>` 等特殊 token 在解码时被跳过，从而导致无法调用工具的问题。